### PR TITLE
Added check for backup directory existence.

### DIFF
--- a/Hyper-V-Backup.ps1
+++ b/Hyper-V-Backup.ps1
@@ -514,6 +514,13 @@ If ($Vms.count -ne 0)
     ## Display current config ends here.
     ##
 
+    ## Make sure the backup directory exists .
+    If ((Test-Path($Backup)) -eq $False)
+    {
+        Write-Log -Type "Info" -Event "Backup directory $Backup does not exist. Creating."
+        New-Item $Backup -ItemType "directory"
+    }
+
     ##
     ## -NoPerms process starts here.
     ##


### PR DESCRIPTION
If the backup directory doesn't exist then the first VM will be backed up to a file with no extension and the name of the backup directory. All further VMs will be backed up in the working directory (if different from $Backup) and will fail to copy across as the destination "directory" is a file. This commit should fix this issue.